### PR TITLE
Add onSearch prop to the Combobox

### DIFF
--- a/packages/core/src/components/Combobox/Combobox.tsx
+++ b/packages/core/src/components/Combobox/Combobox.tsx
@@ -67,6 +67,7 @@ const _Combobox: ComboboxComponent = forwardRef(
       mode,
       offset,
       onChange,
+      onSearch,
       optionColor,
       placeholder,
       radius,
@@ -226,6 +227,9 @@ const _Combobox: ComboboxComponent = forwardRef(
         onChange={(event) => {
           setSearching(true);
           setSearch(event.target.value);
+          if (onSearch) {
+            onSearch(event.target.value);
+          }
 
           if (!open) {
             setOpen(true);

--- a/packages/core/src/components/Combobox/Combobox.types.ts
+++ b/packages/core/src/components/Combobox/Combobox.types.ts
@@ -30,6 +30,7 @@ export interface ComboboxProps extends Omit<ComponentPropsWithRef<'div'>, 'onCha
   mode?: ComboboxMode;
   offset?: number;
   onChange?(value: string | null | undefined): void;
+  onSearch?(value: string | null | undefined): void;
   optionColor?: ComboboxOptionColor;
   placeholder?: string;
   radius?: ComboboxRadius;


### PR DESCRIPTION
This PR adds an onSearch prop to the Combobox to read the users input value.

**Note:**
I would have preferred to use the `onChange` prop for this and change it's current use to `onSelect` but this would break the API on the component I realise.

**Use case:**
If a user wants to query an endpoint for Combobox options which will be queried and narrowed down as the user starts typing. Think locations for example.