### PR TITLE
Docs: Correct Combobox component closing tag.

### DIFF
--- a/apps/docs/ui/configurators/components/Combobox.example.tsx
+++ b/apps/docs/ui/configurators/components/Combobox.example.tsx
@@ -66,7 +66,7 @@ function App() {
       <Combobox.Option value="1" label="Apple" />
       <Combobox.Option value="2" label="Orange" />
       <Combobox.Option value="3" label="Banana" />
-    </Select>
+    </Combobox>
   );
 }
 `.trim();


### PR DESCRIPTION
This PR just replaces the incorrect closing tag of the Combobox component from `</Select>` to `</Combobox` in the documentation