### PR TITLE
Add autoComplete attribute set to off by default to Combobox component

### DIFF
--- a/packages/core/src/components/Combobox/Combobox.tsx
+++ b/packages/core/src/components/Combobox/Combobox.tsx
@@ -224,6 +224,7 @@ const _Combobox: ComboboxComponent = forwardRef(
         placeholder={placeholder}
         className={inputClasses}
         readOnly={!searchable}
+        autoComplete="off"
         onBlur={() => setSearching(false)}
         onChange={(event) => {
           setSearching(true);


### PR DESCRIPTION
The Combobox component, there is the possibility as it is in my case, that the browser autocompletes the input field, so this should not happen. No Combobox should be autocompleted by the browser.

In case of any changes or modifications, let's do it.
Thank you.