### PR TITLE
fix(storybook): change alignment of text in table's header & footer

### DIFF
--- a/apps/storybook/stories/Table.stories.tsx
+++ b/apps/storybook/stories/Table.stories.tsx
@@ -152,8 +152,10 @@ const Template = (args: TableProps) => (
   <Table {...args}>
     <Table.Thead>
       <Table.Tr>
-        {headings.map((heading: string) => (
-          <Table.Th key={heading}>{heading}</Table.Th>
+        {headings.map((heading: string, index: number) => (
+          <Table.Th key={heading} align={index === 0 ? 'center' : 'left'}>
+            {heading}
+          </Table.Th>
         ))}
       </Table.Tr>
     </Table.Thead>
@@ -169,8 +171,8 @@ const Template = (args: TableProps) => (
     </Table.Tbody>
     <Table.Tfoot>
       <Table.Tr>
-        {headings.map((heading: string) => (
-          <Table.Td key={heading} align="center">
+        {headings.map((heading: string, index: number) => (
+          <Table.Td key={heading} align={index === 0 ? 'center' : 'left'}>
             {heading}
           </Table.Td>
         ))}


### PR DESCRIPTION
### Summary
This PR addresses the alignment inconsistency observed in the Storybook example of the Rewind-UI project. The previous state had center-aligned table headers and footers, while the table body cells had varying alignments. To enhance the visual consistency of the table, I have made the following changes:
- Center-align the first column headers and footers.
- Left-align the remaining headers and footers.

These changes result in a more visually appealing and uniform table layout.

### Fixes/Enhancements
- Center-align first column headers and footers.
- Left-align other headers and footers.
- Achieve a visually polished and consistent table layout.

### Related Issue
close #90

### Screenshots
![image](https://github.com/rewindui/rewindui/assets/40722529/aa8ce5d4-a2fc-4358-9eec-03bb2ce89b21)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the visual presentation of tables in our application. The first column of each table now aligns centrally, while all other columns align to the left. This change improves readability and consistency across all tables within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->