### PR TITLE
Fix Tailwind style detection

### DIFF
--- a/.changeset/early-jokes-dream.md
+++ b/.changeset/early-jokes-dream.md
@@ -1,0 +1,5 @@
+---
+'@rewind-ui/core': patch
+---
+
+Vite hotfix

--- a/packages/core/rollup.config.mjs
+++ b/packages/core/rollup.config.mjs
@@ -32,7 +32,18 @@ const tscAlias = () => {
   };
 };
 
-export default [
+// Custom plugin to conditionally apply the terser plugin
+const conditionalTerser = (excludedPatterns, options) => ({
+  name: 'conditional-terser',
+  renderChunk(code, chunk) {
+    if (excludedPatterns.some((pattern) => pattern.test(chunk.fileName))) {
+      return { code, map: null }; // Skip minification
+    }
+    return terser().renderChunk.call(this, code, chunk, options);
+  },
+});
+
+const config = [
   {
     input: 'src/index.ts',
     output: [
@@ -70,7 +81,7 @@ export default [
       }),
       typescriptPaths(),
       preserveDirectives(),
-      terser({ compress: { directives: false } }),
+      conditionalTerser([/theme\/styles\/.*.styles.js/], { compress: { directives: false } }),
       copy({
         targets: [{ src: './../../README.md', dest: 'dist' }],
       }),
@@ -83,3 +94,5 @@ export default [
     },
   },
 ];
+
+export default config;


### PR DESCRIPTION
Tailwind was not able to fully parse minified files for RewindUI components as all the code was on a VERY long single line.

The fix is to not minify the `*.styles.js` files.

This was done by creating a custom plugin that only calls `terser` for files that don't match the exclusion pattern.