### PR TITLE
Changed type of the label prop in `Sidebar.Nav.Section.Item` to ReactNode

### DIFF
--- a/.changeset/sixty-chefs-build.md
+++ b/.changeset/sixty-chefs-build.md
@@ -1,0 +1,5 @@
+---
+'@rewind-ui/core': minor
+---
+
+Adjusted Sidebar Item label type

--- a/apps/docs/content/components/sidebar.mdx
+++ b/apps/docs/content/components/sidebar.mdx
@@ -186,10 +186,20 @@ The `Sidebar.Nav.Section.Item` component is used to render an item of a section.
 <View>
   <Sidebar>
     <Sidebar.Nav>
-      <Sidebar.Nav.Section>
-        <Sidebar.Nav.Section.Item icon={<RocketLaunch />} label="Dashboard" href="#" active />
-      </Sidebar.Nav.Section>
-    </Sidebar.Nav>
+          <Sidebar.Nav.Section>
+            <Sidebar.Nav.Section.Item
+              icon={<RocketLaunch />}
+              label={
+                <span>
+                  Dashboard
+                  <Badge color="red" size="xs" className="ml-1">Beta</Badge>
+                </span>
+              }
+              href="#"
+              active
+            />
+          </Sidebar.Nav.Section>
+        </Sidebar.Nav>
   </Sidebar>
 </View>
 ```
@@ -338,7 +348,7 @@ export const App = () => {
 | as        | `ElementType`         | Defines the type of the rendered element | `a`         |
 | asProps   | `Record<string, any>` | Defines the as Element properties        | `undefined` |
 | icon      | `ReactNode`           | Sets the item icon                       | `undefined` |
-| label     | `string`              | Sets the item label                      | `undefined` |
+| label     | `ReactNode`           | Sets the item label                      | `undefined` |
 | active    | `boolean`             | Sets the item state                      | `false`     |
 | collapsed | `boolean`             | Sets the item's initial collapsed state  | `true`      |
 

--- a/apps/docs/content/components/sidebar.mdx
+++ b/apps/docs/content/components/sidebar.mdx
@@ -192,7 +192,7 @@ The `Sidebar.Nav.Section.Item` component is used to render an item of a section.
               label={
                 <span>
                   Dashboard
-                  <Badge color="red" size="xs" className="ml-1">Beta</Badge>
+                  <Badge color="red" size="xs" className="ml-2">Beta</Badge>
                 </span>
               }
               href="#"

--- a/apps/docs/ui/configurators/components/Sidebar.showcase.tsx
+++ b/apps/docs/ui/configurators/components/Sidebar.showcase.tsx
@@ -5,7 +5,7 @@ import { EnvelopeOpen } from '@/ui/icons/EnvelopeOpen';
 import { Shield } from '@/ui/icons/Shield';
 import { Sliders } from '@/ui/icons/Sliders';
 import { Users } from '@/ui/icons/Users';
-import { Button, Overlay, Sidebar, SidebarProps, SidebarState, useSidebar } from '@rewind-ui/core';
+import { Badge, Button, Overlay, Sidebar, SidebarProps, SidebarState, useSidebar } from '@rewind-ui/core';
 import { ReactNode, useState } from 'react';
 import * as React from 'react';
 import Image from 'next/image';
@@ -352,7 +352,17 @@ const Item = () => {
 
         <Sidebar.Nav>
           <Sidebar.Nav.Section>
-            <Sidebar.Nav.Section.Item icon={<RocketLaunch />} label="Dashboard" href="#" active />
+            <Sidebar.Nav.Section.Item
+              icon={<RocketLaunch />}
+              label={
+                <span>
+                  Dashboard
+                  <Badge color="red" size="xs" className="ml-1">Beta</Badge>
+                </span>
+              }
+              href="#"
+              active
+            />
           </Sidebar.Nav.Section>
         </Sidebar.Nav>
       </Sidebar>

--- a/apps/docs/ui/configurators/components/Sidebar.showcase.tsx
+++ b/apps/docs/ui/configurators/components/Sidebar.showcase.tsx
@@ -5,7 +5,15 @@ import { EnvelopeOpen } from '@/ui/icons/EnvelopeOpen';
 import { Shield } from '@/ui/icons/Shield';
 import { Sliders } from '@/ui/icons/Sliders';
 import { Users } from '@/ui/icons/Users';
-import { Badge, Button, Overlay, Sidebar, SidebarProps, SidebarState, useSidebar } from '@rewind-ui/core';
+import {
+  Badge,
+  Button,
+  Overlay,
+  Sidebar,
+  SidebarProps,
+  SidebarState,
+  useSidebar,
+} from '@rewind-ui/core';
 import { ReactNode, useState } from 'react';
 import * as React from 'react';
 import Image from 'next/image';
@@ -175,7 +183,7 @@ const Head = () => {
       >
         <Sidebar.Head>
           <Sidebar.Head.Logo>
-            <Image src="/images/rewind.svg" width={48} height={48} alt="Rewind-UI" />
+            <Logo />
           </Sidebar.Head.Logo>
           <Sidebar.Head.Title>Rewind-UI</Sidebar.Head.Title>
           <Sidebar.Head.Toggle />
@@ -200,7 +208,7 @@ const Nav = () => {
       >
         <Sidebar.Head>
           <Sidebar.Head.Logo>
-            <Image src="/images/rewind.svg" width={48} height={48} alt="Rewind-UI" />
+            <Logo />
           </Sidebar.Head.Logo>
           <Sidebar.Head.Title>Rewind-UI</Sidebar.Head.Title>
           <Sidebar.Head.Toggle />
@@ -236,7 +244,7 @@ const RenderAs = () => {
       >
         <Sidebar.Head>
           <Sidebar.Head.Logo>
-            <Image src="/images/rewind.svg" width={48} height={48} alt="Rewind-UI" />
+            <Logo />
           </Sidebar.Head.Logo>
           <Sidebar.Head.Title>Rewind-UI</Sidebar.Head.Title>
           <Sidebar.Head.Toggle />
@@ -273,7 +281,7 @@ const Title = () => {
       >
         <Sidebar.Head>
           <Sidebar.Head.Logo>
-            <Image src="/images/rewind.svg" width={48} height={48} alt="Rewind-UI" />
+            <Logo />
           </Sidebar.Head.Logo>
           <Sidebar.Head.Title>Rewind-UI</Sidebar.Head.Title>
           <Sidebar.Head.Toggle />
@@ -310,7 +318,7 @@ const Separator = () => {
       >
         <Sidebar.Head>
           <Sidebar.Head.Logo>
-            <Image src="/images/rewind.svg" width={48} height={48} alt="Rewind-UI" />
+            <Logo />
           </Sidebar.Head.Logo>
           <Sidebar.Head.Title>Rewind-UI</Sidebar.Head.Title>
           <Sidebar.Head.Toggle />
@@ -344,7 +352,7 @@ const Item = () => {
       >
         <Sidebar.Head>
           <Sidebar.Head.Logo>
-            <Image src="/images/rewind.svg" width={48} height={48} alt="Rewind-UI" />
+            <Logo />
           </Sidebar.Head.Logo>
           <Sidebar.Head.Title>Rewind-UI</Sidebar.Head.Title>
           <Sidebar.Head.Toggle />
@@ -357,7 +365,9 @@ const Item = () => {
               label={
                 <span>
                   Dashboard
-                  <Badge color="red" size="xs" className="ml-1">Beta</Badge>
+                  <Badge color="red" size="xs" className="ml-2">
+                    Beta
+                  </Badge>
                 </span>
               }
               href="#"
@@ -385,7 +395,7 @@ const ChildItems = () => {
       >
         <Sidebar.Head>
           <Sidebar.Head.Logo>
-            <Image src="/images/rewind.svg" width={48} height={48} alt="Rewind-UI" />
+            <Logo />
           </Sidebar.Head.Logo>
           <Sidebar.Head.Title>Rewind-UI</Sidebar.Head.Title>
           <Sidebar.Head.Toggle />
@@ -438,7 +448,7 @@ const Footer = () => {
       >
         <Sidebar.Head>
           <Sidebar.Head.Logo>
-            <Image src="/images/rewind.svg" width={48} height={48} alt="Rewind-UI" />
+            <Logo />
           </Sidebar.Head.Logo>
           <Sidebar.Head.Title>Rewind-UI</Sidebar.Head.Title>
           <Sidebar.Head.Toggle />

--- a/packages/core/src/components/Sidebar/SidebarNav/SidebarNavSection/SidebarNavSectionItem/SidebarNavSectionItem.types.ts
+++ b/packages/core/src/components/Sidebar/SidebarNav/SidebarNavSection/SidebarNavSectionItem/SidebarNavSectionItem.types.ts
@@ -12,7 +12,7 @@ export interface SidebarNavSectionItemProps extends ComponentPropsWithRef<'li'> 
   asProps?: Record<string, any>;
   href?: string;
   icon?: ReactNode;
-  label: string;
+  label: ReactNode;
   active?: boolean;
   collapsed?: boolean;
 }


### PR DESCRIPTION
### Summary:

I changed the type of the label prop in `Sidebar.Nav.Section.Item` from string to ReactNode.

### Changes Made:

* packages/core/src/components/Sidebar/SidebarNav/SidebarNavSection/SidebarNavSectionItem/SidebarNavSectionItem.types.ts
  * Changed the type
* apps/docs/ui/configurators/components/Sidebar.showcase.tsx
  * Added an example using the `Badge` Component for the label of the `Item` component
  * If you don't need this, just delete it.
* apps/docs/content/components/sidebar.mdx
  * Made the same changes as in Sidebar.showcase.tsx
  * If you don't need this, just delete it.

Please let me know if any other changes are needed.

### Why This Change:

I wanted to add elements like "NEW" or "Beta" to the label of Sidebar Items, similar to the sidebar in the documentation. However, since the label element of `Sidebar.Nav.Section.Item` is of a type string, I changed it to ReactNode.

![sidebar_of_document](https://github.com/user-attachments/assets/9e60dceb-249c-47fe-ba22-e37bbf34ee6b)

This is how it works when using the `Badge` Component:

![how_it_works](https://github.com/user-attachments/assets/1384cfdd-6217-4794-8624-9034f94192a8)

### Testing:

**Note**: As there are no existing tests for the Sidebar, I have not conducted any tests. Please let me know if I am mistaken.